### PR TITLE
Fix the  typo in #error message of DETECTNULL macro

### DIFF
--- a/newlib/libc/string/strncpy.c
+++ b/newlib/libc/string/strncpy.c
@@ -69,7 +69,7 @@ QUICKREF
 #endif
 
 #ifndef DETECTNULL
-#error long int is not a 32bit or 64bit byte
+#error long int is not a 32bit or 64bit type.
 #endif
 
 #define TOO_SMALL(LEN) ((LEN) < sizeof (long))


### PR DESCRIPTION
Fix the  typo in #error message of DETECTNULL macro
old: #error long int is not a 32bit or 64bit byte 
new: #error long int is not a 32bit or 64bit type.